### PR TITLE
Fix issues with files that are not missing the EOF EOL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weighted-assign-action",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Automatically distributes PR reviews",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ function getReviewers() {
   return fs
     .readFileSync(configPath, 'utf8')
     .split('\n')
-    .map(r => r.split(' '))
+    .map(r => r.split(/\s+/))
+    .filter(r => r[0] !== '')
     .map(reviewer => ({
       username: reviewer[0],
       weight: reviewer[1] == undefined ? 0 : parseFloat(reviewer[1])


### PR DESCRIPTION
The script assumes that the last line of the file will not have a newline char, but nearly all editors in the world will create files that have a newline char before the EOF. If you edit the file in an editor you'll get this for `reviewers`:

```
[
  { username: 'jackiegorman', weight: 1 },
  { username: 'B-Evans99', weight: 1 },
  { username: 'chrisfosterelli', weight: 1 },
  { username: 'avvaikethees', weight: 1 },
  { username: '', weight: 0 }
]
```

This fix filters that out. It also improves the whitespace handling, so even files like this will be interpreted correctly:

```
jackiegorman 1
B-Evans99   1

chrisfosterelli 1

avvaikethees     1

  

```